### PR TITLE
Fix russian translate in "outer size" term

### DIFF
--- a/terms/css-box-sizing/outer_size.json
+++ b/terms/css-box-sizing/outer_size.json
@@ -1,5 +1,5 @@
 {
-  "name_ru": "внутренний размер",
+  "name_ru": "внешний размер",
   "name_eng": "outer size",
   "define_ru": "[Размер](/size) [бокса отступов](/margin_box) заданного бокса.",
   "define_eng": "The margin-box size of a box.",


### PR DESCRIPTION
Поправил небольшую опечатку в русском переводе `outer size`